### PR TITLE
Fix build warnings

### DIFF
--- a/crypto/crypto_scrypt-sse.c
+++ b/crypto/crypto_scrypt-sse.c
@@ -48,7 +48,7 @@
 
 static void blkcpy(void *, void *, size_t);
 static void blkxor(void *, void *, size_t);
-static void salsa20_8(__m128i *);
+static void salsa20_8(__m128i [4]);
 static void blockmix_salsa8(__m128i *, __m128i *, __m128i *, size_t);
 static uint64_t integerify(void *, size_t);
 static void smix(uint8_t *, size_t, uint64_t, void *, void *);

--- a/php_scrypt.c
+++ b/php_scrypt.c
@@ -187,7 +187,7 @@ PHP_FUNCTION(scrypt_pickparams)
 	zend_long maxmem;
 	double memfrac, maxtime;
 
-	zend_long cryptN;
+	int cryptN;
 	uint32_t cryptR, cryptP;
 
 	int rc;


### PR DESCRIPTION
at least the [-Wincompatible-pointer-types] can raise bad issue, especially on big endian